### PR TITLE
Azure Pipelines: Upgrade to image windows-2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,25 +17,25 @@ jobs:
   - job: Windows
 
     pool:
-      vmImage: 'VS2017-Win2016'
+      vmImage: 'windows-2022'
 
     strategy:
       matrix:
         Win32:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: Win32
           CONFIGURATION: Release
         Win64:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
         Win64-UWP:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
         ARM64-UWP:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: ARM64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"


### PR DESCRIPTION
The windows-2016 environment is deprecated and will be removed on April 1st, 2022. This changes CI image to windows-2022.