### PR TITLE
Parse series title and episode name from epg

### DIFF
--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.plutotv"
-  version="20.1.0"
+  version="20.2.0"
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.0
+- Parse series title and episode name from epg
+
 v20.1.0
 - Kodi main API update to version 2.0.0
 

--- a/src/PlutotvData.cpp
+++ b/src/PlutotvData.cpp
@@ -454,27 +454,46 @@ PVR_ERROR PlutotvData::GetEPGForChannel(int channelUid,
 
         if (epgData.HasMember("episode"))
         {
+          const auto& episode = epgData["episode"];
           // set description
-          if (epgData["episode"].HasMember("description") &&
-              epgData["episode"]["description"].IsString())
+          if (episode.HasMember("description") &&
+              episode["description"].IsString())
           {
-            tag.SetPlot(epgData["episode"]["description"].GetString());
-            kodi::Log(ADDON_LOG_DEBUG, "[epg] description: %s;",
-                      epgData["episode"]["description"].GetString());
+            tag.SetPlot(episode["description"].GetString());
+            kodi::Log(ADDON_LOG_DEBUG, "[epg] description: %s;", episode["description"].GetString());
           }
 
           // genre
-          if (epgData["episode"].HasMember("genre") && epgData["episode"]["genre"].IsString())
+          if (episode.HasMember("genre") && episode["genre"].IsString())
           {
             tag.SetGenreType(EPG_GENRE_USE_STRING);
-            tag.SetGenreDescription(epgData["episode"]["genre"].GetString());
+            tag.SetGenreDescription(episode["genre"].GetString());
           }
 
           // thumbnail
-          if (epgData["episode"].HasMember("thumbnail") &&
-              epgData["episode"]["thumbnail"]["path"].IsString())
+          if (episode.HasMember("thumbnail") &&
+              episode["thumbnail"]["path"].IsString())
           {
-            tag.SetIconPath(epgData["episode"]["thumbnail"]["path"].GetString());
+            tag.SetIconPath(episode["thumbnail"]["path"].GetString());
+          }
+
+          // series title / episode name
+          if (episode.HasMember("series") &&
+              episode["series"].HasMember("name") &&
+              episode["series"]["name"].IsString() &&
+              episode.HasMember("name") &&
+              episode["name"].IsString())
+          {
+            // series title
+            tag.SetTitle(episode["series"]["name"].GetString());
+            kodi::Log(ADDON_LOG_DEBUG, "[epg] series title: %s;", episode["series"]["name"].GetString());
+
+            // episode name
+            tag.SetEpisodeName(episode["name"].GetString());
+            kodi::Log(ADDON_LOG_DEBUG, "[epg] episode name: %s;", episode["name"].GetString());
+
+            // set is series
+            tag.SetFlags(EPG_TAG_FLAG_IS_SERIES);
           }
         }
 


### PR DESCRIPTION
## Description

As wished by user Solo0815 in [Kodi forum](https://forum.kodi.tv/showthread.php?tid=367931), this PR adds parsing series title and episode name from Pluto epg, if available.

~~Not tested yet, because I am currently unable to compile Kodi on arch linux.~~

Edit: Tested on arch linux.

## Screenshots

**Before:**

![Before](https://user-images.githubusercontent.com/4031504/180647221-dfd7d6ac-4084-4132-bb8c-18a5889cd97f.png)

**After:**

![After](https://user-images.githubusercontent.com/4031504/180647228-1178d2c2-8c43-4974-bb5e-692c5ed1419d.png)


