### PR TITLE
Revert version increase of dependency

### DIFF
--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -5,7 +5,7 @@
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@
-    <import addon="script.module.inputstreamhelper" version="21.0.0"/>
+    <import addon="script.module.inputstreamhelper" version="0.4.1"/>
     <import addon="inputstream.adaptive" minversion="21.0.0"/>
   </requires>
   <extension


### PR DESCRIPTION
Branch script inadvertently bumped versioning for imports.

For binary addons, the bump to 21.0.0 is fine, and expected, however for this python script, we need to stay with its versioning.