### PR TITLE
settings: Add setting for the first channel number used

### DIFF
--- a/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
@@ -30,6 +30,10 @@ msgctxt "#30007"
 msgid "(Re)install Widevine CDM library"
 msgstr ""
 
+msgctxt "#30008"
+msgid "First channel number"
+msgstr ""
+
 msgctxt "#30040"
 msgid "Debug"
 msgstr ""

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -3,6 +3,14 @@
 	<section id="pvr.plutotv">
 		<category id="credentials" label="30001" help="">
 			<group id="1" label="">
+				<setting id="start_channelnum" type="integer" label="30008" help="">
+					<level>0</level>
+					<default>1</default>
+					<constraints>
+						<allowempty>false</allowempty>
+					</constraints>
+					<control type="edit" format="integer" />
+				</setting>
 				<setting id="install_widevine" type="string" label="30007"
 					help="">
 					<level>0</level>

--- a/src/PlutotvData.cpp
+++ b/src/PlutotvData.cpp
@@ -113,7 +113,8 @@ bool PlutotvData::LoadChannelsData()
   kodi::Log(ADDON_LOG_DEBUG, "[channels] iterate channels");
   kodi::Log(ADDON_LOG_DEBUG, "[channels] size: %i;", channelsDoc["result"].Size());
 
-  int i = 0;
+  // Use configured start channel number to populate the channel list
+  int i = GetSettingsStartChannel();
   for (const auto& channel : channelsDoc["result"].GetArray())
   {
     /**
@@ -153,9 +154,9 @@ bool PlutotvData::LoadChannelsData()
       }}, */
 
     const std::string plutotvid = channel["_id"].GetString();
-    ++i;
+
     PlutotvChannel plutotv_channel;
-    plutotv_channel.iChannelNumber = i; // position
+    plutotv_channel.iChannelNumber = i++; // position
     kodi::Log(ADDON_LOG_DEBUG, "[channel] channelnr(pos): %i;", plutotv_channel.iChannelNumber);
 
     plutotv_channel.plutotvID = plutotvid;
@@ -260,6 +261,11 @@ std::string PlutotvData::GetSettingsUUID(const std::string& setting)
     kodi::addon::SetSettingString(setting, uuid);
   }
   return uuid;
+}
+
+int PlutotvData::GetSettingsStartChannel() const
+{
+  return kodi::addon::GetSettingInt("start_channelnum", 1);
 }
 
 std::string PlutotvData::GetChannelStreamURL(int uniqueId)

--- a/src/PlutotvData.h
+++ b/src/PlutotvData.h
@@ -74,6 +74,7 @@ private:
 
   std::string GetChannelStreamURL(int uniqueId);
   std::string GetSettingsUUID(const std::string& setting);
+  int GetSettingsStartChannel() const;
   void SetStreamProperties(std::vector<kodi::addon::PVRStreamProperty>& properties,
                            const std::string& url,
                            bool realtime);


### PR DESCRIPTION
Make the first channel number used to populate the channel list configurable as the default of 1 very likely conflicts with other PVR backend channel list when multiple backends are activated.