### PR TITLE
Add setting to work around broken HLS streams provided by pluto.tv …

### DIFF
--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.plutotv"
-  version="21.1.1"
+  version="21.2.0"
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,3 +1,6 @@
+v21.2.0
+- Add setting to work around broken HLS streams provided by pluto.tv (requires inputstream.adaptive > 21.4.5)
+
 v21.1.1
 - Translations updates from Weblate
 	- af_za, am_et, ar_sa, ast_es, az_az, be_by, bg_bg, bs_ba, ca_es, cs_cz, cy_gb, da_dk, de_de, el_gr, en_au, en_nz, en_us, eo, es_ar, es_es, es_mx, et_ee, eu_es, fa_af, fa_ir, fi_fi, fo_fo, fr_ca, fr_fr, gl_es, he_il, hi_in, hr_hr, hu_hu, hy_am, id_id, is_is, it_it, ja_jp, ko_kr, lt_lt, lv_lv, mi, mk_mk, ml_in, mn_mn, ms_my, mt_mt, my_mm, nb_no, nl_nl, pl_pl, pt_br, pt_pt, ro_ro, ru_ru, si_lk, sk_sk, sl_si, sq_al, sr_rs, sr_rs@latin, sv_se, szl, ta_in, te_in, tg_tj, th_th, tr_tr, uk_ua, uz_uz, vi_vn, zh_cn, zh_tw

--- a/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
@@ -34,6 +34,10 @@ msgctxt "#30008"
 msgid "First channel number"
 msgstr ""
 
+msgctxt "#30009"
+msgid "Workaround for broken streams (requires inputstream.adaptive > 21.4.5)"
+msgstr ""
+
 msgctxt "#30040"
 msgid "Debug"
 msgstr ""

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <settings version="1">
 	<section id="pvr.plutotv">
-		<category id="credentials" label="30001" help="">
+		<category id="general" label="30001" help="">
 			<group id="1" label="">
 				<setting id="start_channelnum" type="integer" label="30008" help="">
 					<level>0</level>
@@ -11,8 +11,12 @@
 					</constraints>
 					<control type="edit" format="integer" />
 				</setting>
-				<setting id="install_widevine" type="string" label="30007"
-					help="">
+				<setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
+					<level>2</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="install_widevine" type="string" label="30007" help="">
 					<level>0</level>
 					<default />
 					<constraints>
@@ -25,8 +29,7 @@
 					<dependency type="visible" operator="!is"
 						setting="system.platform.android">true</dependency>
 				</setting>
-				<setting id="run_is_info" type="string" label="30006"
-					help="">
+				<setting id="run_is_info" type="string" label="30006" help="">
 					<level>0</level>
 					<default />
 					<constraints>
@@ -35,15 +38,13 @@
 					<control type="button" format="action">
 						<data>RunScript(script.module.inputstreamhelper,info)</data>
 					</control>
-					<dependency type="visible" operator="!is"
-						setting="system.platform.android">true</dependency>
+					<dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
 				</setting>
 			</group>
 		</category>
 		<category id="debug" label="30040" help="">
 			<group id="1" label="">
-				<setting id="internal_sid" type="string" label="30041"
-					help="">
+				<setting id="internal_sid" type="string" label="30041" help="">
 					<level>3</level>
 					<default />
 					<constraints>
@@ -51,8 +52,7 @@
 					</constraints>
 					<control type="edit" format="string"></control>
 				</setting>
-				<setting id="internal_deviceid" type="string" label="30042"
-					help="">
+				<setting id="internal_deviceid" type="string" label="30042" help="">
 					<level>3</level>
 					<default />
 					<constraints>

--- a/src/PlutotvData.cpp
+++ b/src/PlutotvData.cpp
@@ -76,10 +76,10 @@ void PlutotvData::SetStreamProperties(std::vector<kodi::addon::PVRStreamProperty
   properties.emplace_back(PVR_STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
   properties.emplace_back(PVR_STREAM_PROPERTY_ISREALTIMESTREAM, realtime ? "true" : "false");
   // HLS
-  kodi::Log(ADDON_LOG_DEBUG, "[PLAY STREAM] hls");
-  properties.emplace_back("inputstream.adaptive.manifest_type", "hls");
   properties.emplace_back(PVR_STREAM_PROPERTY_MIMETYPE, "application/x-mpegURL");
-  properties.emplace_back("inputstream.adaptive.manifest_update_parameter", "full");
+  if (GetSettingsWorkaroundBrokenStreams())
+    properties.emplace_back("inputstream.adaptive.manifest_config",
+                            "{\"hls_ignore_endlist\":true,\"hls_fix_mediasequence\":true,\"hls_fix_discsequence\":true}");
 }
 
 bool PlutotvData::LoadChannelsData()
@@ -266,6 +266,11 @@ std::string PlutotvData::GetSettingsUUID(const std::string& setting)
 int PlutotvData::GetSettingsStartChannel() const
 {
   return kodi::addon::GetSettingInt("start_channelnum", 1);
+}
+
+bool PlutotvData::GetSettingsWorkaroundBrokenStreams() const
+{
+  return kodi::addon::GetSettingBoolean("workaround_broken_streams", true);
 }
 
 std::string PlutotvData::GetChannelStreamURL(int uniqueId)

--- a/src/PlutotvData.h
+++ b/src/PlutotvData.h
@@ -75,6 +75,7 @@ private:
   std::string GetChannelStreamURL(int uniqueId);
   std::string GetSettingsUUID(const std::string& setting);
   int GetSettingsStartChannel() const;
+  bool GetSettingsWorkaroundBrokenStreams() const;
   void SetStreamProperties(std::vector<kodi::addon::PVRStreamProperty>& properties,
                            const std::string& url,
                            bool realtime);


### PR DESCRIPTION
…(requires inputstream.adaptive > 21.4.5).

Requires https://github.com/xbmc/inputstream.adaptive/pull/1532, so this PR should only merged after ia fix is publicly available.

