### PR TITLE
Add setting for color logo, some settings changes

### DIFF
--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.plutotv"
-  version="21.2.0"
+  version="21.3.0"
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@

--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -5,7 +5,6 @@
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@
-    <import addon="script.module.inputstreamhelper" version="0.4.1"/>
     <import addon="inputstream.adaptive" minversion="21.0.0"/>
   </requires>
   <extension

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.0
+- Introduce a setting to toggle between monochrome and color channel logos (default: color)
+
 v21.2.0
 - Add setting to work around broken HLS streams provided by pluto.tv (requires inputstream.adaptive > 21.4.5)
 

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,5 +1,6 @@
 v21.3.0
 - Introduce a setting to toggle between monochrome and color channel logos (default: color)
+- Remove Inputstreamhelper addon dependency and related settings (pluto.tv streams are unencrypted).
 
 v21.2.0
 - Add setting to work around broken HLS streams provided by pluto.tv (requires inputstream.adaptive > 21.4.5)

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,6 +1,7 @@
 v21.3.0
-- Introduce a setting to toggle between monochrome and color channel logos (default: color)
+- Introduce a setting to toggle between monochrome and color channel logos (default: color).
 - Remove Inputstreamhelper addon dependency and related settings (pluto.tv streams are unencrypted).
+- Add help texts for settings.
 
 v21.2.0
 - Add setting to work around broken HLS streams provided by pluto.tv (requires inputstream.adaptive > 21.4.5)

--- a/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
@@ -22,6 +22,10 @@ msgctxt "#30001"
 msgid "General"
 msgstr ""
 
+msgctxt "#30002"
+msgid "Channels"
+msgstr ""
+
 msgctxt "#30006"
 msgid "InputStream Helper information"
 msgstr ""
@@ -36,6 +40,10 @@ msgstr ""
 
 msgctxt "#30009"
 msgid "Workaround for broken streams (requires inputstream.adaptive > 21.4.5)"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Coloured channel logos"
 msgstr ""
 
 msgctxt "#30040"

--- a/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
@@ -49,3 +49,27 @@ msgstr ""
 msgctxt "#30042"
 msgid "Device ID"
 msgstr ""
+
+msgctxt "#30100"
+msgid "Category containing playback settings"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Enable special stream handling to avoid hangs during playback."
+msgstr ""
+
+msgctxt "#30200"
+msgid "Category containing channel settings"
+msgstr ""
+
+msgctxt "#30201"
+msgid "The number for the first channel. Useful if you have multiple PVR clients enabled - to group the channels from the different clients."
+msgstr ""
+
+msgctxt "#30202"
+msgid "Use coulored channel logos, if available."
+msgstr ""
+
+msgctxt "#30300"
+msgid "Category containing debug settings"
+msgstr ""

--- a/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.plutotv/resources/language/resource.language.en_gb/strings.po
@@ -19,19 +19,11 @@ msgid "Pluto.tv PVR Client. Note: This is not an official pluto.tv add-on and no
 msgstr ""
 
 msgctxt "#30001"
-msgid "General"
+msgid "Playback"
 msgstr ""
 
 msgctxt "#30002"
 msgid "Channels"
-msgstr ""
-
-msgctxt "#30006"
-msgid "InputStream Helper information"
-msgstr ""
-
-msgctxt "#30007"
-msgid "(Re)install Widevine CDM library"
 msgstr ""
 
 msgctxt "#30008"

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" ?>
 <settings version="1">
   <section id="pvr.plutotv">
-    <category id="playback" label="30001" help="">
+    <category id="playback" label="30001" help="30100">
       <group id="1" label="">
-        <setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
+        <setting id="workaround_broken_streams" type="boolean" label="30009" help="30101">
           <level>2</level>
           <default>true</default>
           <control type="toggle"/>
         </setting>
       </group>
     </category>
-    <category id="channels" label="30002" help="">
+    <category id="channels" label="30002" help="30200">
       <group id="1" label="">
-        <setting id="start_channelnum" type="integer" label="30008" help="-1">
+        <setting id="start_channelnum" type="integer" label="30008" help="30201">
           <level>0</level>
           <default>1</default>
           <constraints>
@@ -20,14 +20,14 @@
           </constraints>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="colored_channel_logos" type="boolean" label="30010" help="-1">
+        <setting id="colored_channel_logos" type="boolean" label="30010" help="30202">
           <level>0</level>
           <default>true</default>
           <control type="toggle"/>
         </setting>
       </group>
     </category>
-    <category id="debug" label="30040" help="">
+    <category id="debug" label="30040" help="30300">
       <group id="1" label="">
         <setting id="internal_sid" type="string" label="30041" help="-1">
           <level>3</level>

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" ?>
 <settings version="1">
-	<section id="pvr.plutotv">
-		<category id="general" label="30001" help="">
-			<group id="1" label="">
-				<setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
-					<level>2</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="install_widevine" type="string" label="30007" help="">
-					<level>0</level>
-					<default />
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="button" format="action">
-						<data>RunScript(script.module.inputstreamhelper,widevine_install)
-						</data>
-					</control>
-					<dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
-				</setting>
-				<setting id="run_is_info" type="string" label="30006" help="">
-					<level>0</level>
-					<default />
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="button" format="action">
-						<data>RunScript(script.module.inputstreamhelper,info)</data>
-					</control>
-					<dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
-				</setting>
-			</group>
-		</category>
-		<category id="channels" label="30002" help="">
-			<group id="1" label="">
-				<setting id="start_channelnum" type="integer" label="30008" help="">
-					<level>0</level>
-					<default>1</default>
-					<constraints>
-						<allowempty>false</allowempty>
-					</constraints>
-					<control type="edit" format="integer" />
-				</setting>
-				<setting id="colored_channel_logos" type="boolean" label="30010" help="-1">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-		</category>
-		<category id="debug" label="30040" help="">
-			<group id="1" label="">
-				<setting id="internal_sid" type="string" label="30041" help="">
-					<level>3</level>
-					<default />
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string"></control>
-				</setting>
-				<setting id="internal_deviceid" type="string" label="30042" help="">
-					<level>3</level>
-					<default />
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string"></control>
-				</setting>
-			</group>
-		</category>
-	</section>
+  <section id="pvr.plutotv">
+    <category id="general" label="30001" help="">
+      <group id="1" label="">
+        <setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+        <setting id="install_widevine" type="string" label="30007" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="button" format="action">
+            <data>RunScript(script.module.inputstreamhelper,widevine_install)
+            </data>
+          </control>
+          <dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
+        </setting>
+        <setting id="run_is_info" type="string" label="30006" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="button" format="action">
+            <data>RunScript(script.module.inputstreamhelper,info)</data>
+          </control>
+          <dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
+        </setting>
+      </group>
+    </category>
+    <category id="channels" label="30002" help="">
+      <group id="1" label="">
+        <setting id="start_channelnum" type="integer" label="30008" help="">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="colored_channel_logos" type="boolean" label="30010" help="-1">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+      </group>
+    </category>
+    <category id="debug" label="30040" help="">
+      <group id="1" label="">
+        <setting id="internal_sid" type="string" label="30041" help="">
+          <level>3</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string"></control>
+        </setting>
+        <setting id="internal_deviceid" type="string" label="30042" help="">
+          <level>3</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string"></control>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -3,14 +3,6 @@
 	<section id="pvr.plutotv">
 		<category id="general" label="30001" help="">
 			<group id="1" label="">
-				<setting id="start_channelnum" type="integer" label="30008" help="">
-					<level>0</level>
-					<default>1</default>
-					<constraints>
-						<allowempty>false</allowempty>
-					</constraints>
-					<control type="edit" format="integer" />
-				</setting>
 				<setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
 					<level>2</level>
 					<default>true</default>
@@ -26,8 +18,7 @@
 						<data>RunScript(script.module.inputstreamhelper,widevine_install)
 						</data>
 					</control>
-					<dependency type="visible" operator="!is"
-						setting="system.platform.android">true</dependency>
+					<dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
 				</setting>
 				<setting id="run_is_info" type="string" label="30006" help="">
 					<level>0</level>
@@ -39,6 +30,23 @@
 						<data>RunScript(script.module.inputstreamhelper,info)</data>
 					</control>
 					<dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
+				</setting>
+			</group>
+		</category>
+		<category id="channels" label="30002" help="">
+			<group id="1" label="">
+				<setting id="start_channelnum" type="integer" label="30008" help="">
+					<level>0</level>
+					<default>1</default>
+					<constraints>
+						<allowempty>false</allowempty>
+					</constraints>
+					<control type="edit" format="integer" />
+				</setting>
+				<setting id="colored_channel_logos" type="boolean" label="30010" help="-1">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
 				</setting>
 			</group>
 		</category>

--- a/pvr.plutotv/resources/settings.xml
+++ b/pvr.plutotv/resources/settings.xml
@@ -1,41 +1,18 @@
 <?xml version="1.0" ?>
 <settings version="1">
   <section id="pvr.plutotv">
-    <category id="general" label="30001" help="">
+    <category id="playback" label="30001" help="">
       <group id="1" label="">
         <setting id="workaround_broken_streams" type="boolean" label="30009" help="-1">
           <level>2</level>
           <default>true</default>
           <control type="toggle"/>
         </setting>
-        <setting id="install_widevine" type="string" label="30007" help="">
-          <level>0</level>
-          <default />
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <control type="button" format="action">
-            <data>RunScript(script.module.inputstreamhelper,widevine_install)
-            </data>
-          </control>
-          <dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
-        </setting>
-        <setting id="run_is_info" type="string" label="30006" help="">
-          <level>0</level>
-          <default />
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <control type="button" format="action">
-            <data>RunScript(script.module.inputstreamhelper,info)</data>
-          </control>
-          <dependency type="visible" operator="!is" setting="system.platform.android">true</dependency>
-        </setting>
       </group>
     </category>
     <category id="channels" label="30002" help="">
       <group id="1" label="">
-        <setting id="start_channelnum" type="integer" label="30008" help="">
+        <setting id="start_channelnum" type="integer" label="30008" help="-1">
           <level>0</level>
           <default>1</default>
           <constraints>
@@ -52,7 +29,7 @@
     </category>
     <category id="debug" label="30040" help="">
       <group id="1" label="">
-        <setting id="internal_sid" type="string" label="30041" help="">
+        <setting id="internal_sid" type="string" label="30041" help="-1">
           <level>3</level>
           <default />
           <constraints>
@@ -60,7 +37,7 @@
           </constraints>
           <control type="edit" format="string"></control>
         </setting>
-        <setting id="internal_deviceid" type="string" label="30042" help="">
+        <setting id="internal_deviceid" type="string" label="30042" help="-1">
           <level>3</level>
           <default />
           <constraints>

--- a/src/PlutotvData.h
+++ b/src/PlutotvData.h
@@ -75,6 +75,7 @@ private:
   std::string GetChannelStreamURL(int uniqueId);
   std::string GetSettingsUUID(const std::string& setting);
   int GetSettingsStartChannel() const;
+  bool GetSettingsColoredChannelLogos() const;
   bool GetSettingsWorkaroundBrokenStreams() const;
   void SetStreamProperties(std::vector<kodi::addon::PVRStreamProperty>& properties,
                            const std::string& url,


### PR DESCRIPTION
v21.3.0
- Introduce a setting to toggle between monochrome and color channel logos (default: color).
- Remove Inputstreamhelper addon dependency and related settings (pluto.tv streams are unencrypted).
- Add help texts for settings.