### PR TITLE
Fix EPG refresh not working (due to expired JWT)

### DIFF
--- a/pvr.plutotv/addon.xml.in
+++ b/pvr.plutotv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.plutotv"
-  version="22.3.0"
+  version="22.3.1"
   name="Pluto.tv PVR Client"
   provider-name="Team Kodi, flubshi">
   <requires>@ADDON_DEPENDS@

--- a/pvr.plutotv/changelog.txt
+++ b/pvr.plutotv/changelog.txt
@@ -1,3 +1,6 @@
+v22.3.1
+- Fix EPG refresh not working (due to expired JWT)
+
 v22.3.0
 - Add support for channel groups (map pluto categories to channel groups).
 

--- a/src/PlutotvData.cpp
+++ b/src/PlutotvData.cpp
@@ -506,7 +506,7 @@ PVR_ERROR PlutotvData::GetEPGForChannel(int channelUid,
       {
         kodi::addon::PVREPGTag tag;
 
-        // generate a unique boadcast id
+        // generate a unique broadcast id
         const std::string epg_bsid = epgData.at("_id");
         kodi::Log(ADDON_LOG_DEBUG, "[epg] epg_bsid: %s;", epg_bsid.c_str());
         const int epg_bid = Utils::Hash(epg_bsid);
@@ -604,7 +604,6 @@ PVR_ERROR PlutotvData::GetEPGForChannel(int channelUid,
               episode.at("name").is_string())
           {
             // series title
-
             const std::string seriesTitle{episode.at("series").at("name")};
             tag.SetTitle(seriesTitle);
             kodi::Log(ADDON_LOG_DEBUG, "[epg] series title: %s", seriesTitle.c_str());

--- a/src/PlutotvData.cpp
+++ b/src/PlutotvData.cpp
@@ -105,10 +105,6 @@ bool PlutotvData::LoadChannelsData()
   if (m_bChannelsLoaded)
     return true;
 
-  GetJWT();
-  if (m_jwt.empty())
-    return false;
-
   kodi::Log(ADDON_LOG_DEBUG, "[load data] GET CHANNELS");
 
   const std::string jsonChannels{GetChannelsJson()};
@@ -265,7 +261,7 @@ PVR_ERROR PlutotvData::GetChannelStreamProperties(
   return ret;
 }
 
-std::string PlutotvData::GetSettingsUUID(const std::string& setting)
+std::string PlutotvData::GetSettingsUUID(const std::string& setting) const
 {
   std::string uuid = kodi::addon::GetSettingString(setting);
   if (uuid.empty())
@@ -305,7 +301,7 @@ std::string PlutotvData::GetChannelStreamURL(int uniqueId)
       kodi::Log(ADDON_LOG_DEBUG, "Get live url for channel %s", channel.strChannelName.c_str());
 
       // Complete stream URL with JWT.
-      const std::string streamURL{channel.strStreamURL + m_jwt};
+      const std::string streamURL{channel.strStreamURL + GetJWT()};
       kodi::Log(ADDON_LOG_DEBUG, "stream URL: %s", streamURL.c_str());
       return streamURL;
     }
@@ -317,10 +313,6 @@ bool PlutotvData::LoadCategoriesData()
 {
   if (m_categoriesLoaded)
     return true;
-
-  GetJWT();
-  if (m_jwt.empty())
-    return false;
 
   kodi::Log(ADDON_LOG_DEBUG, "[load data] GET CATEGORIES");
 
@@ -630,52 +622,83 @@ PVR_ERROR PlutotvData::GetEPGForChannel(int channelUid,
   return PVR_ERROR_INVALID_PARAMETERS;
 }
 
-std::string PlutotvData::GetJWT()
+bool PlutotvData::IsExpiredTokenResponse(const HttpResponse& response) const
 {
-  // JWT expires after 24 hours
-  if (m_jwt.empty() || (std::chrono::steady_clock::now() - m_jwtTimestamp > std::chrono::hours(23)))
+  if (response.statusCode != 401)
+    return false;
+
+  nlohmann::json doc = nlohmann::json::parse(response.body, nullptr, false);
+  if (doc.is_discarded())
+    return false;
+
+  return doc.value("errorCode", "") == "InvalidExpiredBearerToken";
+}
+
+std::string PlutotvData::AuthenticatedGet(Curl& curl, const std::string& url) const
+{
+  curl.AddHeader("authorization", "Bearer " + GetJWT());
+
+  int statusCode{500};
+  std::string body{curl.Get(url, statusCode)};
+
+  if (IsExpiredTokenResponse({statusCode, body}))
   {
-    std::string url{"https://boot.pluto.tv/v4/start"};
-    url += "?appName=web";
-    url += "&appVersion=1.0.0";
-    url += "&deviceVersion=122.0.0"; // has to match user agent?
-    url += "&deviceModel=web";
-    url += "&deviceMake=chrome"; // has to match user agent?
-    url += "&deviceType=web";
-    url += "&clientID=" + GetSettingsUUID("internal_clientid");
-    url += "&clientModelNumber=1.0.0";
-    url += "&serverSideAds=false";
-    url += "&drmCapabilities=widevine%3AL3"; // Widevine L3 device
-    url += "&blockingMode=";
-    url += "&notificationVersion=1";
-    url += "&appLaunchCount=";
-    url += "&lastAppLaunchDate=";
-
+    kodi::Log(ADDON_LOG_DEBUG, "[AuthenticatedGet] JWT expired (401), refreshing and retrying.");
     m_jwt.clear();
+    curl.AddHeader("authorization", "Bearer " + GetJWT());
+    body = curl.Get(url, statusCode);
+  }
 
-    Curl curl;
-    curl.AddHeader("User-Agent", PLUTOTV_USER_AGENT);
+  if (statusCode == 200)
+    return body;
 
-    int statusCode{500};
-    const std::string json{curl.Get(url, statusCode)};
-    if (statusCode == 200)
+  kodi::Log(ADDON_LOG_ERROR, "[AuthenticatedGet] ERROR. status: %i, url: %s", statusCode,
+            url.c_str());
+  return {};
+}
+
+std::string PlutotvData::GetJWT() const
+{
+  if (!m_jwt.empty())
+    return m_jwt;
+
+  std::string url{"https://boot.pluto.tv/v4/start"};
+  url += "?appName=web";
+  url += "&appVersion=1.0.0";
+  url += "&deviceVersion=122.0.0"; // has to match user agent?
+  url += "&deviceModel=web";
+  url += "&deviceMake=chrome"; // has to match user agent?
+  url += "&deviceType=web";
+  url += "&clientID=" + GetSettingsUUID("internal_clientid");
+  url += "&clientModelNumber=1.0.0";
+  url += "&serverSideAds=false";
+  url += "&drmCapabilities=widevine%3AL3"; // Widevine L3 device
+  url += "&blockingMode=";
+  url += "&notificationVersion=1";
+  url += "&appLaunchCount=";
+  url += "&lastAppLaunchDate=";
+
+  Curl curl;
+  curl.AddHeader("User-Agent", PLUTOTV_USER_AGENT);
+
+  int statusCode{500};
+  const std::string json{curl.Get(url, statusCode)};
+  if (statusCode == 200)
+  {
+    nlohmann::json doc = nlohmann::json::parse(json.c_str());
+    if (doc.is_discarded())
     {
-      nlohmann::json doc = nlohmann::json::parse(json.c_str());
-      if (doc.is_discarded())
-      {
-        kodi::Log(ADDON_LOG_ERROR, "[GetJWT] ERROR: error while parsing json");
-      }
-      else
-      {
-        m_jwt = doc.at("sessionToken");
-        m_jwtTimestamp = std::chrono::steady_clock::now();
-        kodi::Log(ADDON_LOG_DEBUG, "[GetJWT]: New JWT: %s.", m_jwt.c_str());
-      }
+      kodi::Log(ADDON_LOG_ERROR, "[GetJWT] ERROR: error while parsing json");
     }
     else
     {
-      kodi::Log(ADDON_LOG_ERROR, "[GetJWT] error. status: %i, body: %s", statusCode, json.c_str());
+      m_jwt = doc.at("sessionToken");
+      kodi::Log(ADDON_LOG_DEBUG, "[GetJWT]: New JWT: %s.", m_jwt.c_str());
     }
+  }
+  else
+  {
+    kodi::Log(ADDON_LOG_ERROR, "[GetJWT] error. status: %i, body: %s", statusCode, json.c_str());
   }
   return m_jwt;
 }
@@ -692,22 +715,11 @@ std::string PlutotvData::GetChannelsJson() const
   curl.AddHeader("authority", "service-channels.clusters.pluto.tv");
   curl.AddHeader("accept", "*/*");
   curl.AddHeader("accept-language", "en-US,en;q=0.9");
-  curl.AddHeader("authorization", "Bearer " + m_jwt);
   curl.AddHeader("origin", "https://pluto.tv");
   curl.AddHeader("referer", "https://pluto.tv/");
   curl.AddHeader("user-agent", PLUTOTV_USER_AGENT);
 
-  int statusCode{500};
-  const std::string json{curl.Get(url, statusCode)};
-  if (statusCode == 200)
-  {
-    kodi::Log(ADDON_LOG_DEBUG, "[GetChannelsJson] Response: %s.", json.c_str());
-    return json;
-  }
-
-  kodi::Log(ADDON_LOG_ERROR, "[GetChannelsJson] ERROR. status: %i, body: %s", statusCode,
-            json.c_str());
-  return {};
+  return AuthenticatedGet(curl, url);
 }
 
 std::string PlutotvData::GetCategoriesJson() const
@@ -722,22 +734,11 @@ std::string PlutotvData::GetCategoriesJson() const
   curl.AddHeader("authority", "service-channels.clusters.pluto.tv");
   curl.AddHeader("accept", "*/*");
   curl.AddHeader("accept-language", "en-US,en;q=0.9");
-  curl.AddHeader("authorization", "Bearer " + m_jwt);
   curl.AddHeader("origin", "https://pluto.tv");
   curl.AddHeader("referer", "https://pluto.tv/");
   curl.AddHeader("user-agent", PLUTOTV_USER_AGENT);
 
-  int statusCode{500};
-  const std::string json{curl.Get(url, statusCode)};
-  if (statusCode == 200)
-  {
-    kodi::Log(ADDON_LOG_DEBUG, "[GetCategoriesJson] Response: %s.", json.c_str());
-    return json;
-  }
-
-  kodi::Log(ADDON_LOG_ERROR, "[GetCategoriesJson] ERROR. status: %i, body: %s", statusCode,
-            json.c_str());
-  return {};
+  return AuthenticatedGet(curl, url);
 }
 
 std::string PlutotvData::GetEpgJson(time_t start) const
@@ -755,21 +756,11 @@ std::string PlutotvData::GetEpgJson(time_t start) const
   curl.AddHeader("authority", "service-channels.clusters.pluto.tv");
   curl.AddHeader("accept", "*/*");
   curl.AddHeader("accept-language", "en-US,en;q=0.9");
-  curl.AddHeader("authorization", "Bearer " + m_jwt);
   curl.AddHeader("origin", "https://pluto.tv");
   curl.AddHeader("referer", "https://pluto.tv/");
   curl.AddHeader("user-agent", PLUTOTV_USER_AGENT);
 
-  int statusCode{500};
-  const std::string json{curl.Get(url, statusCode)};
-  if (statusCode == 200)
-  {
-    kodi::Log(ADDON_LOG_DEBUG, "[GetEpgJson] Response: %s.", json.c_str());
-    return json;
-  }
-
-  kodi::Log(ADDON_LOG_ERROR, "[GetEpgJson] ERROR. status: %i, body: %s", statusCode, json.c_str());
-  return "";
+  return AuthenticatedGet(curl, url);
 }
 
 ADDONCREATOR(PlutotvData)

--- a/src/PlutotvData.h
+++ b/src/PlutotvData.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "kodi/addon-instance/PVR.h"
-#include <nlohmann/json.hpp>
 
-#include <chrono>
 #include <memory>
 #include <vector>
+
+#include <nlohmann/json.hpp>
+
+class Curl;
 
 /**
  * User Agent for HTTP Requests
@@ -67,6 +69,13 @@ private:
     std::string strStreamURL;
   };
 
+  // Wraps an HTTP response for error analysis
+  struct HttpResponse
+  {
+    int statusCode{500};
+    std::string body;
+  };
+
   std::shared_ptr<nlohmann::json> m_epg_cache_document;
   time_t m_epg_cache_start = time_t(0);
   time_t m_epg_cache_end = time_t(0);
@@ -75,7 +84,7 @@ private:
   bool m_bChannelsLoaded = false;
 
   std::string GetChannelStreamURL(int uniqueId);
-  std::string GetSettingsUUID(const std::string& setting);
+  std::string GetSettingsUUID(const std::string& setting) const;
   int GetSettingsStartChannel() const;
   bool GetSettingsColoredChannelLogos() const;
   bool GetSettingsWorkaroundBrokenStreams() const;
@@ -95,11 +104,24 @@ private:
   std::vector<PlutotvCategory> m_categories;
   bool m_categoriesLoaded{false};
 
-  std::string GetJWT();
+  // Returns true if the response indicates an expired JWT (HTTP 401 + errorCode
+  // "InvalidExpiredBearerToken"). Used by AuthenticatedGet to decide whether to
+  // refresh the token and retry the request.
+  bool IsExpiredTokenResponse(const HttpResponse& response) const;
+
+  // Performs an authenticated GET request. Adds the current JWT as Bearer token.
+  // On HTTP 401 with errorCode "InvalidExpiredBearerToken" the token is cleared,
+  // a new one is fetched via GetJWT(), and the request is retried exactly once.
+  // Returns the response body on success, or an empty string on failure.
+  // Note: 'curl' must already have all headers except "authorization" set by the caller.
+  std::string AuthenticatedGet(Curl& curl, const std::string& url) const;
+
+  std::string GetJWT() const;
   std::string GetChannelsJson() const;
   std::string GetCategoriesJson() const;
   std::string GetEpgJson(time_t start) const;
 
-  std::string m_jwt;
-  std::chrono::time_point<std::chrono::steady_clock> m_jwtTimestamp;
+  // mutable: m_jwt is a cached session token that may be transparently refreshed
+  // by AuthenticatedGet() on HTTP 401, even from const API methods.
+  mutable std::string m_jwt;
 };


### PR DESCRIPTION
fix: refresh JWT session token on HTTP 401 InvalidExpiredBearerToken

Replace the hardcoded 23-hour timer with reactive token refresh:
- Add AuthenticatedGet() which retries once on HTTP 401 with  errorCode "InvalidExpiredBearerToken"
- Add IsExpiredTokenResponse() to detect the specific API error
- Make m_jwt mutable so const API methods can transparently refresh
- Fix GetChannelStreamURL() to call GetJWT() instead of using  the stale m_jwt member directly
- Remove m_jwtTimestamp and the <chrono> dependency